### PR TITLE
Feature/#13194 supports urls with path variables in the http call flow step from http endpoint 

### DIFF
--- a/flowSteps/httpCall/step.js
+++ b/flowSteps/httpCall/step.js
@@ -24,7 +24,7 @@ step.httpCall = function (stepConfig) {
 	var body = isObject(stepConfig.inputs.body) ? stepConfig.inputs.body : JSON.parse(stepConfig.inputs.body);
 
 	var options = {
-		path: parse( stepConfig.inputs.url, stepConfig.inputs.pathVariables),
+		path: parse(stepConfig.inputs.url.urlValue, stepConfig.inputs.url.paramsValue),
 		params:params,
 		headers:headers,
 		body: body,

--- a/flowSteps/httpCall/step.js
+++ b/flowSteps/httpCall/step.js
@@ -14,7 +14,7 @@
  * @param {number} connectionTimeout, Read timeout interval, in milliseconds.
  * @param {number} readTimeout, Connect timeout interval, in milliseconds.
  */
-step.httpCall = function (method, url, headers, params, body, requiresCallBack,
+step.httpCall = function (method, url,pathVariables, headers, params, body, requiresCallBack,
 						  callbackData, callbacks, overrideSettings, followRedirects,
 						  download, fullResponse,connectionTimeout, readTimeout) {
 
@@ -23,7 +23,7 @@ step.httpCall = function (method, url, headers, params, body, requiresCallBack,
 	body = isObject(body) ? body : JSON.parse(body);
 
 	var options = {
-		path: url,
+		path: parse( url, pathVariables),
 		params:params,
 		headers:headers,
 		body: body,
@@ -59,6 +59,20 @@ step.httpCall = function (method, url, headers, params, body, requiresCallBack,
 
 };
 
+var parse = function (url, pathVariables){
+
+	if(pathVariables){
+		url = url.replace(/:([a-zA-Z]+)/g, function(m, i) {
+			if (pathVariables[i]){
+				return pathVariables[i];
+			}else{
+				return m;
+			}
+		})
+	}
+
+	return url;
+}
 var isObject = function (obj) {
 	return !!obj && stringType(obj) === '[object Object]'
 };

--- a/flowSteps/httpCall/step.js
+++ b/flowSteps/httpCall/step.js
@@ -4,6 +4,7 @@
  * @param {object} stepConfig.inputs
  * {text} method, This is used to config method.
  * {text} url, This is used to config external URL.
+ * {Array[string]} pathVariables, This is used to config path variables.
  * {Array[string]} headers, This is used to config headers.
  * {Array[string]} params, This is used to config params.
  * {string} body, This is used to send body request.
@@ -23,7 +24,7 @@ step.httpCall = function (stepConfig) {
 	var body = isObject(stepConfig.inputs.body) ? stepConfig.inputs.body : JSON.parse(stepConfig.inputs.body);
 
 	var options = {
-		path: parse( stepConfig.inputs.url,stepConfig.inputs.pathVariables),
+		path: parse( stepConfig.inputs.url, stepConfig.inputs.pathVariables),
 		params:params,
 		headers:headers,
 		body: body,

--- a/flowSteps/httpCall/step.js
+++ b/flowSteps/httpCall/step.js
@@ -61,16 +61,18 @@ step.httpCall = function (method, url,pathVariables, headers, params, body, requ
 
 var parse = function (url, pathVariables){
 
-	if (!url.includes(':')){
+	var regex = /{([^}]*)}/g;
+
+	if (!url.match(regex)){
 		return url;
 	}
 
 	if(!pathVariables){
-		sys.logs.error('No path variables have been received and the url contains \':\'');
+		sys.logs.error('No path variables have been received and the url contains curly brackets\'{}\'');
 		throw new Error('Error please contact support.');
 	}
 
-	url = url.replace(/:([a-zA-Z]+)/g, function(m, i) {
+	url = url.replace(regex, function(m, i) {
 		return pathVariables[i] ? pathVariables[i] : m;
 	})
 

--- a/flowSteps/httpCall/step.js
+++ b/flowSteps/httpCall/step.js
@@ -61,15 +61,18 @@ step.httpCall = function (method, url,pathVariables, headers, params, body, requ
 
 var parse = function (url, pathVariables){
 
-	if(pathVariables){
-		url = url.replace(/:([a-zA-Z]+)/g, function(m, i) {
-			if (pathVariables[i]){
-				return pathVariables[i];
-			}else{
-				return m;
-			}
-		})
+	if (!url.includes(':')){
+		return url;
 	}
+
+	if(!pathVariables){
+		sys.logs.error('No path variables have been received and the url contains \':\'');
+		throw new Error('Error please contact support.');
+	}
+
+	url = url.replace(/:([a-zA-Z]+)/g, function(m, i) {
+		return pathVariables[i] ? pathVariables[i] : m;
+	})
 
 	return url;
 }

--- a/flowSteps/httpCall/step.js
+++ b/flowSteps/httpCall/step.js
@@ -29,7 +29,9 @@ step.httpCall = function (stepConfig) {
 		headers:headers,
 		body: body,
 		followRedirects : stepConfig.inputs.followRedirects,
-		download : stepConfig.inputs.download,
+		forceDownload : stepConfig.inputs.download,
+		downloadSync : stepConfig.inputs.downloadSync,
+		fileName: stepConfig.inputs.fileName,
 		fullResponse : stepConfig.inputs.fullResponse,
 		connectionTimeout: stepConfig.inputs.connectionTimeout,
 		readTimeout: stepConfig.inputs.readTimeout

--- a/flowSteps/httpCall/step.json
+++ b/flowSteps/httpCall/step.json
@@ -69,19 +69,28 @@
 			"label": "Path Variables",
 			"name": "pathVariables",
 			"description": "If your request requires a path variable, you should add this entry, e.g.: userId = 1",
-			"type": "keyValue"
+			"type": "keyValue",
+			"options": {
+				"allowContextSelector": "false"
+			}
 		},
 		{
 			"label": "Headers",
 			"name": "headers",
 			"description": "The headers have the 'key=value' form, per example: key=ABC123",
-			"type": "keyValue"
+			"type": "keyValue",
+			"options": {
+				"allowContextSelector": "false"
+			}
 		},
 		{
 			"label": "Params",
 			"name": "params",
 			"description": "The params have the 'key=value' form, per example: key=ABC123",
-			"type": "keyValue"
+			"type": "keyValue",
+			"options": {
+				"allowContextSelector": "false"
+			}
 		},
 		{
 			"label": "Body",

--- a/flowSteps/httpCall/step.json
+++ b/flowSteps/httpCall/step.json
@@ -60,28 +60,19 @@
 			"name": "url",
 			"description": "The URL to which this endpoint will send the request. Use curly brackets if you require path variables e.g.: https://app.slinger/user/{userId}",
 			"type": "urlParams",
-			"required": "true",
-			"options": {
-				"allowContextSelector": "false"
-			}
+			"required": "true"
 		},
 		{
 			"label": "Headers",
 			"name": "headers",
 			"description": "The headers have the 'key=value' form, per example: key=ABC123",
-			"type": "keyValue",
-			"options": {
-				"allowContextSelector": "false"
-			}
+			"type": "keyValue"
 		},
 		{
 			"label": "Params",
 			"name": "params",
 			"description": "The params have the 'key=value' form, per example: key=ABC123",
-			"type": "keyValue",
-			"options": {
-				"allowContextSelector": "false"
-			}
+			"type": "keyValue"
 		},
 		{
 			"label": "Body",
@@ -150,11 +141,32 @@
 			"label": "Download",
 			"name": "download",
 			"type": "boolean",
-			"description": "Determines if the HTTP resource will be downloaded",
+			"description": "Indicates that the resource has to be downloaded into a file instead of returning it in the response.",
 			"visibility": "config.overrideSettings",
 			"defaultValue": false,
 			"options": {
 				"allowContextSelector": "false"
+			}
+		},
+		{
+			"label": "Download Sync",
+			"name": "downloadSync",
+			"type": "boolean",
+			"description": "If true the method won't return until the file has been downloaded and it will return all the information of the file.",
+			"visibility": "config.overrideSettings",
+			"defaultValue": false,
+			"options": {
+				"allowContextSelector": "false"
+			}
+		},
+		{
+			"label": "File Name",
+			"name": "fileName",
+			"description": "If provided, the file will be stored with this name. If empty the file name will be calculated from the URL.",
+			"visibility": "config.overrideSettings",
+			"type": "text",
+			"options": {
+				"allowContextSelector": "true"
 			}
 		},
 		{

--- a/flowSteps/httpCall/step.json
+++ b/flowSteps/httpCall/step.json
@@ -58,7 +58,7 @@
 		{
 			"label": "URL",
 			"name": "url",
-			"description": "The URL to which this endpoint will send the request.",
+			"description": "The URL to which this endpoint will send the request. Use curly brackets if you require path variables e.g.: https://app.slinger/user/{userId}",
 			"type": "text",
 			"required": "true",
 			"options": {
@@ -68,7 +68,7 @@
 		{
 			"label": "Path Variables",
 			"name": "pathVariables",
-			"description": "If your request requires a path variable, you should add this entry",
+			"description": "If your request requires a path variable, you should add this entry, e.g.: userId = 1",
 			"type": "keyValue"
 		},
 		{

--- a/flowSteps/httpCall/step.json
+++ b/flowSteps/httpCall/step.json
@@ -66,6 +66,15 @@
 			}
 		},
 		{
+			"label": "Path Variables",
+			"name": "pathVariables",
+			"description": "If your request requires a path variable, you should add this entry",
+			"type": "keyValue",
+			"options": {
+				"allowContextSelector": "false"
+			}
+		},
+		{
 			"label": "Headers",
 			"name": "headers",
 			"description": "The headers have the 'key=value' form, per example: key=ABC123",

--- a/flowSteps/httpCall/step.json
+++ b/flowSteps/httpCall/step.json
@@ -149,7 +149,7 @@
 			"name": "followRedirects",
 			"type": "boolean",
 			"description": "Follow the redirects when a HTTP request is executed",
-			"visibility": "config.settings",
+			"visibility": "config.overrideSettings",
 			"defaultValue": false,
 			"options": {
 				"allowContextSelector": "false"
@@ -160,7 +160,7 @@
 			"name": "download",
 			"type": "boolean",
 			"description": "Determines if the HTTP resource will be downloaded",
-			"visibility": "config.settings",
+			"visibility": "config.overrideSettings",
 			"defaultValue": false,
 			"options": {
 				"allowContextSelector": "false"
@@ -171,7 +171,7 @@
 			"name": "fullResponse",
 			"type": "boolean",
 			"description": "Include extended information about response",
-			"visibility": "config.settings",
+			"visibility": "config.overrideSettings",
 			"defaultValue": false,
 			"options": {
 				"allowContextSelector": "false"
@@ -181,7 +181,7 @@
 			"label": "Connection timeout",
 			"name": "connectionTimeout",
 			"description": "Connect timeout interval, in milliseconds (0 = infinity). Default value: 5000 ms (5 sec)",
-			"visibility": "config.settings",
+			"visibility": "config.overrideSettings",
 			"type": "text",
 			"defaultValue": "5000",
 			"typeOptions": {
@@ -198,7 +198,7 @@
 			"label": "Read timeout",
 			"name": "readTimeout",
 			"description": "Read timeout interval, in milliseconds (0 = infinity). Default value: 60000 ms (60 sec)",
-			"visibility": "config.settings",
+			"visibility": "config.overrideSettings",
 			"type": "text",
 			"defaultValue": "60000",
 			"typeOptions": {

--- a/flowSteps/httpCall/step.json
+++ b/flowSteps/httpCall/step.json
@@ -70,6 +70,8 @@
 			"name": "pathVariables",
 			"description": "If your request requires a path variable, you should add this entry",
 			"type": "keyValue",
+			"visibility": "config.url.includes(':')",
+			"required": "config.url.includes(':')",
 			"options": {
 				"allowContextSelector": "false"
 			}

--- a/flowSteps/httpCall/step.json
+++ b/flowSteps/httpCall/step.json
@@ -69,9 +69,7 @@
 			"label": "Path Variables",
 			"name": "pathVariables",
 			"description": "If your request requires a path variable, you should add this entry",
-			"type": "keyValue",
-			"visibility": "config.url.indexOf(':') > -1",
-			"required": "config.url.indexOf(':') > -1"
+			"type": "keyValue"
 		},
 		{
 			"label": "Headers",

--- a/flowSteps/httpCall/step.json
+++ b/flowSteps/httpCall/step.json
@@ -70,29 +70,20 @@
 			"name": "pathVariables",
 			"description": "If your request requires a path variable, you should add this entry",
 			"type": "keyValue",
-			"visibility": "config.url.includes(':')",
-			"required": "config.url.includes(':')",
-			"options": {
-				"allowContextSelector": "false"
-			}
+			"visibility": "config.url.indexOf(':') > -1",
+			"required": "config.url.indexOf(':') > -1"
 		},
 		{
 			"label": "Headers",
 			"name": "headers",
 			"description": "The headers have the 'key=value' form, per example: key=ABC123",
-			"type": "keyValue",
-			"options": {
-				"allowContextSelector": "false"
-			}
+			"type": "keyValue"
 		},
 		{
 			"label": "Params",
 			"name": "params",
 			"description": "The params have the 'key=value' form, per example: key=ABC123",
-			"type": "keyValue",
-			"options": {
-				"allowContextSelector": "false"
-			}
+			"type": "keyValue"
 		},
 		{
 			"label": "Body",

--- a/flowSteps/httpCall/step.json
+++ b/flowSteps/httpCall/step.json
@@ -59,17 +59,8 @@
 			"label": "URL",
 			"name": "url",
 			"description": "The URL to which this endpoint will send the request. Use curly brackets if you require path variables e.g.: https://app.slinger/user/{userId}",
-			"type": "text",
+			"type": "urlParams",
 			"required": "true",
-			"options": {
-				"allowContextSelector": "false"
-			}
-		},
-		{
-			"label": "Path Variables",
-			"name": "pathVariables",
-			"description": "If your request requires a path variable, you should add this entry, e.g.: userId = 1",
-			"type": "keyValue",
 			"options": {
 				"allowContextSelector": "false"
 			}


### PR DESCRIPTION
Pull-request for issue https://github.com/slingr-stack/platform/issues/13194 created by @agreggio-slingr

## What does it do?
Adds support for path variable in httpCall flow step

## How to test it?

1. Config a new http-endpoint 
2. Use http-endpoint and create an action with Action Type -> Flow
3. In the flow designer create a new generic flow with:
     method = Get
     url = https://test1.idea2.io/dev/runtime/api/data/contacts/:id
     Add a Path Variables  with key = id and value=5506fc44c2eee3b1a702694e
     Add a headers with key = token and value = o1ecfO0tRSpUc2HkLODTZF8DLgvfOU9G
     Apply and push changes
 
4. Go to runtime and launch action

## Implementation notes


## Deployment notes
