### PR TITLE
#7 Updated to the new version of the SDK allowing the implementation …

### DIFF
--- a/endpoint.json
+++ b/endpoint.json
@@ -34,6 +34,11 @@
             "label": "File Downloaded",
             "name": "fileDownloaded",
             "description": "Happens when a async download file process is finished (thrown by a GET function with 'forceDownload' enabled and 'downloadSync' disabled)"
+        },
+        {
+            "label": "Callback",
+            "name": "callback",
+            "description": "Happens when a async process is finished"
         }
     ],
     "functions": [
@@ -44,38 +49,71 @@
             "callbacks": [
                 {
                     "name": "fileDownloaded"
+                },
+                {
+                    "name": "callback"
                 }
             ]
         },
         {
             "label": "POST",
             "name": "_post",
-            "description": "Sends a POST request"
+            "description": "Sends a POST request",
+            "callbacks": [
+                {
+                    "name": "callback"
+                }
+            ]
         },
         {
             "label": "PUT",
             "name": "_put",
-            "description": "Sends a PUT request"
+            "description": "Sends a PUT request",
+            "callbacks": [
+                {
+                    "name": "callback"
+                }
+            ]
         },
         {
             "label": "PATCH",
             "name": "_patch",
-            "description": "Sends a PATCH request"
+            "description": "Sends a PATCH request",
+            "callbacks": [
+                {
+                    "name": "callback"
+                }
+            ]
         },
         {
             "label": "DELETE",
             "name": "_delete",
-            "description": "Sends a DELETE request"
+            "description": "Sends a DELETE request",
+            "callbacks": [
+                {
+                    "name": "callback"
+                }
+            ]
         },
         {
             "label": "HEAD",
             "name": "_head",
-            "description": "Sends a HEAD request"
+            "description": "Sends a HEAD request",
+            "callbacks": [
+                {
+                    "name": "callback"
+                }
+            ]
         },
         {
             "label": "OPTIONS",
             "name": "_options",
-            "description": "Sends a OPTIONS request"
+            "description": "Sends a OPTIONS request",
+            "callbacks": [
+                {
+                    "name": "callback"
+                }
+            ]
         }
     ],
     "scripts":[

--- a/flowSteps/httpCall/step.js
+++ b/flowSteps/httpCall/step.js
@@ -23,18 +23,24 @@ step.httpCall = function (stepConfig) {
 	var params = isObject(stepConfig.inputs.params) ? stepConfig.inputs.params : stringToObject(stepConfig.inputs.params)
 	var body = isObject(stepConfig.inputs.body) ? stepConfig.inputs.body : JSON.parse(stepConfig.inputs.body);
 
+	stepConfig.inputs.callbacks = stepConfig.inputs.callbacks ?
+		eval("stepConfig.inputs.callbacks = {" + stepConfig.inputs.events + " : function(event, callbackData) {" + stepConfig.inputs.callbacks + "}}") : stepConfig.inputs.callbacks;
+
+	stepConfig.inputs.callbackData = stepConfig.inputs.callbackData ? {record:stepConfig.inputs.callbackData} : stepConfig.inputs.callbackData;
+
 	var options = {
 		path: parse(stepConfig.inputs.url.urlValue, stepConfig.inputs.url.paramsValue),
 		params:params,
 		headers:headers,
 		body: body,
 		followRedirects : stepConfig.inputs.followRedirects,
-		forceDownload : stepConfig.inputs.download,
-		downloadSync : stepConfig.inputs.downloadSync,
+		forceDownload : stepConfig.inputs.events === "fileDownloaded" ? true : stepConfig.inputs.download,
+		downloadSync : stepConfig.inputs.events === "fileDownloaded" ? false : stepConfig.inputs.download,
 		fileName: stepConfig.inputs.fileName,
 		fullResponse : stepConfig.inputs.fullResponse,
 		connectionTimeout: stepConfig.inputs.connectionTimeout,
-		readTimeout: stepConfig.inputs.readTimeout
+		readTimeout: stepConfig.inputs.readTimeout,
+		defaultCallback: !!stepConfig.inputs.events
 	}
 
 	switch (stepConfig.inputs.method) {

--- a/flowSteps/httpCall/step.json
+++ b/flowSteps/httpCall/step.json
@@ -86,34 +86,45 @@
 			}
 		},
 		{
-			"label": "Requires callback",
-			"name": "requiresCallBack",
-			"type": "boolean",
-			"description": "If true it will return callback",
-			"defaultValue": false,
+			"label": "Event",
+			"name": "events",
+			"type": "dropDown",
+			"description": "Select event",
+			"multiplicity": "one",
 			"options": {
+				"possibleValues": [
+					{
+						"label": "File Downloaded",
+						"name": "fileDownloaded"
+					},
+					{
+						"label": "Callback",
+						"name": "callback"
+					}
+				],
 				"allowContextSelector": "false"
 			}
 		},
 		{
-			"label": "Callback data",
+			"label": "Callback Data",
 			"name": "callbackData",
-			"type": "json",
-			"description": "This is an object you can send that you will get back when the callback is processed",
-			"visibility": "config.requiresCallBack",
+			"type": "text",
+			"description": "This is an object you can send that you will get back when the function is processed",
+			"visibility": "config.events",
 			"options": {
-				"allowContextSelector": "false"
+				"representation": "textArea",
+				"allowContextSelector": "true"
 			}
 		},
 		{
 			"label": "Callbacks",
 			"name": "callbacks",
 			"type": "script",
-			"description": "This is a map where you can listener for different callbacks",
-			"visibility": "config.requiresCallBack",
+			"description": "This is a map where you can listener for different function",
+			"visibility": "config.events",
 			"options": {
 				"allowContextSelector": "false",
-				"parameters": ["event","data"]
+				"parameters": ["event","callbackData"]
 			}
 		},
 		{
@@ -142,18 +153,7 @@
 			"name": "download",
 			"type": "boolean",
 			"description": "Indicates that the resource has to be downloaded into a file instead of returning it in the response.",
-			"visibility": "config.overrideSettings",
-			"defaultValue": false,
-			"options": {
-				"allowContextSelector": "false"
-			}
-		},
-		{
-			"label": "Download Sync",
-			"name": "downloadSync",
-			"type": "boolean",
-			"description": "If true the method won't return until the file has been downloaded and it will return all the information of the file.",
-			"visibility": "config.overrideSettings",
+			"visibility": "config.overrideSettings && config.events != \"fileDownloaded\"",
 			"defaultValue": false,
 			"options": {
 				"allowContextSelector": "false"
@@ -163,7 +163,7 @@
 			"label": "File Name",
 			"name": "fileName",
 			"description": "If provided, the file will be stored with this name. If empty the file name will be calculated from the URL.",
-			"visibility": "config.overrideSettings",
+			"visibility": "(config.overrideSettings && config.download) || config.events === \"fileDownloaded\"",
 			"type": "text",
 			"options": {
 				"allowContextSelector": "true"

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <!-- SLINGR versions -->
-        <slingr.slingr-endpoints.version>1.0-SNAPSHOT</slingr.slingr-endpoints.version>
+        <slingr.slingr-endpoints.version>2.0-SNAPSHOT</slingr.slingr-endpoints.version>
         <!-- Core libraries properties -->
         <log4j.version>2.8.2</log4j.version>
         <logentries.version>1.1.11</logentries.version>


### PR DESCRIPTION
Pull-request for issue #7 created by @agreggio-slingr

## What it does?

1. Added dropdown in http call step allowing to select callback
2. Updated sdk to version 2.0 

## How to test it?

You can test this functionality by using the Http Call step of the http-endpoint. 

1. Create a new event on an entity
2. Use the flow tool
3. Select the Http Call step
4. Select from the Callback drop down and fill in the callback function field with the following code: sys.logs.error("This is a callback test"). 
5. Execute the event from the application, and check that "This is a callback test" is logged in the console.

## Implementation notes

There are no implementation notes.

## Deployment notes

There are no deployment notes