### PR TITLE
#13447 Disable cookie jar / Added support for managing cookies on HTTP Endpoint

### DIFF
--- a/endpoint.json
+++ b/endpoint.json
@@ -153,12 +153,11 @@
         {
             "name": "rememberCookies",
             "label": "Remember cookies",
-            "description": "If it is enabled, a basic system to exchange cookies is started: the endpoint sends the last received cookies in subsequents requests. Valid values 'enable', 'disable', and with placeholders ('Custom' option).",
+            "description": "If it is enabled, a system to exchange cookies is started.",
             "type": "buttonsGroup",
             "required": true,
             "defaultValue": "disable",
             "typeOptions": {
-                "allowCustom": true,
                 "possibleValues":[
                     {
                         "label":"Enable",

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <log4j.version>2.8.2</log4j.version>
         <logentries.version>1.1.11</logentries.version>
         <jackson.version>2.8.0</jackson.version>
-        <jersey.version>2.22.1</jersey.version>
+        <jersey.version>2.39</jersey.version>
         <jericho-html.version>3.4</jericho-html.version>
         <httpclient.version>4.5.3</httpclient.version>
         <commons-io.version>2.5</commons-io.version>

--- a/src/main/resources/endpoint_local.properties
+++ b/src/main/resources/endpoint_local.properties
@@ -18,7 +18,7 @@ _token=f066b77fb8d3f864508f8f8cc762b033e85a3283
 #---------------------
 # no auth
 #---------------------
-_endpoint_config={"baseUrl":"", "defaultHeaders":"", "emptyPath":"", "rememberCookies":"", "allowExternalUrl":"false", "connectionTimeout":"1000", "readTimeout":"1500", "followRedirects":"false", "authType":"", "username":"", "password":""}
+#_endpoint_config={"baseUrl":"", "defaultHeaders":"", "emptyPath":"", "rememberCookies":"", "allowExternalUrl":"false", "connectionTimeout":"1000", "readTimeout":"1500", "followRedirects":"false", "authType":"", "username":"", "password":""}
 
 #---------------------
 # basic auth
@@ -38,3 +38,7 @@ _endpoint_config={"baseUrl":"", "defaultHeaders":"", "emptyPath":"", "rememberCo
 # http://test.webdav.org/auth-digest/
 # http://httpbin.org/digest-auth/auth/user1/user1/MD5
 
+#---------------------
+# Cookies
+#---------------------
+_endpoint_config={"baseUrl":"", "defaultHeaders":"", "emptyPath":"", "rememberCookies":"true", "allowExternalUrl":"false", "connectionTimeout":"1004", "readTimeout":"1504", "followRedirects":"false", "authType":"", "username":"", "password":""}


### PR DESCRIPTION
Pull-request for issue [#13447](https://github.com/slingr-stack/platform/issues/13447) created by @pasaperez-slingr

## What it does?

Updated Jersey library to support the latest HTTP standard and its Cookie handling.
The Custom option of Remember Cookies is removed.

## How to test it?



## Implementation notes

Do a previous cache cleaning and reinstallation of modules.
```
mvn clean install
```

## Deployment notes

A new tag must be created with a higher compatible version than the previous one.